### PR TITLE
Update release workflow for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
   release-stable:
     runs-on: ubuntu-20.04
     name: Release Stable
+    permissions:
+      contents: write
+      id-token: write   # Needed for npm trusted publishing
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:
@@ -18,11 +21,16 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "pnpm"
+
+      # anchor to the smallest npm version supporting trusted publishing
+      - name: Update npm
+        run: npm install -g npm@11.5.1
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -37,7 +45,6 @@ jobs:
           version: pnpm changeset-version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Get current package version
         id: get_version
@@ -54,32 +61,31 @@ jobs:
     name: Release Unstable
     needs: release-stable
     if: always() && github.event_name == 'push' && needs.release-stable.outputs.published == 'false'
+    permissions:
+      contents: write
+      id-token: write   # Needed for npm trusted publishing
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
+
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "pnpm"
 
+      # anchor to the smallest npm version supporting trusted publishing
+      - name: Update npm
+        run: npm install -g npm@11.5.1
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > ".npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create unstable release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # this ensures there's always a patch release created
           cat << 'EOF' > .changeset/snapshot-template-changeset.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       id-token: write   # Needed for npm trusted publishing
+      pull-requests: write
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:
@@ -30,7 +31,7 @@ jobs:
 
       # anchor to the smallest npm version supporting trusted publishing
       - name: Update npm
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@^11
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -64,6 +65,7 @@ jobs:
     permissions:
       contents: write
       id-token: write   # Needed for npm trusted publishing
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -78,7 +80,7 @@ jobs:
 
       # anchor to the smallest npm version supporting trusted publishing
       - name: Update npm
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@^11
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,21 +3,22 @@
   "version": "0.2.0",
   "description": "Core types and functionality of OpenID Federation",
   "license": "Apache-2.0",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    },
-    "./package.json": "./package.json"
-  },
+  "exports": "./src/index.ts",
   "files": ["dist"],
   "publishConfig": {
-    "access": "public",                         // required for scoped packages
-    "registry": "https://registry.npmjs.org/"   // ensure publish goes to npm
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "./package.json": "./package.json"
+    },
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "homepage": "https://github.com/openwallet-foundation-labs/openid-federation-ts/tree/main/packages/core",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,22 +1,23 @@
 {
   "name": "@openid-federation/core",
   "version": "0.2.0",
-  "description": "Core types and functionality of openid federation",
+  "description": "Core types and functionality of OpenID Federation",
   "license": "Apache-2.0",
-  "exports": "./src/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": ["dist"],
   "publishConfig": {
-    "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
-    "types": "./dist/index.d.ts",
-    "exports": {
-      ".": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js",
-        "types": "./dist/index.d.ts"
-      },
-      "./package.json": "./package.json"
-    }
+    "access": "public",                         // required for scoped packages
+    "registry": "https://registry.npmjs.org/"   // ensure publish goes to npm
   },
   "homepage": "https://github.com/openwallet-foundation-labs/openid-federation-ts/tree/main/packages/core",
   "repository": {


### PR DESCRIPTION
Added permissions for contents and id-token to support npm trusted publishing. Removed .npmrc creation step.

Fix: https://github.com/openwallet-foundation-labs/openid-federation-ts/issues/18